### PR TITLE
AtlasOfLivingAustralia/DataQuality#132 Add support for data quality profile parameters to spatial-hub

### DIFF
--- a/grails-app/assets/javascripts/spApp/service/biocacheService.js
+++ b/grails-app/assets/javascripts/spApp/service/biocacheService.js
@@ -696,6 +696,9 @@
                  * @param {List} query q and fq terms
                  * @param {List} fq (optional) one fq term
                  * @param {String} wkt (optional) WKT search value
+                 * @param {String} qualityProfile (optional) quality profile
+                 * @param {Array} disableQualityFilter (optional) quality filters to disable
+                 * @param {Boolean} disableAllQualityFilters (optional) whether to disable all quality filters
                  * @returns {Promise(Integer)} qid
                  *
                  * @example
@@ -708,11 +711,14 @@
                  * Output:
                  * 1234
                  */
-                registerParam: function (bs, q, fq, wkt) {
+                registerParam: function (bs, q, fq, wkt, qualityProfile, disableAllQualityFilters, disableQualityFilter) {
                     var data = {q: q, bs: bs};
                     if ($SH.qc !== undefined && $SH.qc !== null && $SH.qc.length > 0) data.qc = $SH.qc;
                     if (fq !== undefined && fq !== null) data.fq = fq;
                     if (wkt !== undefined && wkt !== null && wkt.length > 0) data.wkt = wkt;
+                    if (disableAllQualityFilters !== undefined && disableAllQualityFilters !== null) data.disableAllQualityFilters = disableAllQualityFilters;
+                    if (qualityProfile !== undefined && qualityProfile !== null) data.qualityProfile = qualityProfile;
+                    if (disableQualityFilter !== undefined && disableQualityFilter !== null) data.disableQualityFilter = disableQualityFilter;
                     return $http.post($SH.baseUrl + "/portal/q", data, _httpDescription('registerParam')).then(function (response) {
                         if (!isNaN(response.data.qid)) {
                             return response.data
@@ -803,7 +809,7 @@
                     }
                     if (query.wkt !== undefined) wkt = query.wkt;
 
-                    return this.registerLayer(query.bs, query.ws, fq, wkt, newName)
+                    return this.registerLayer(query.bs, query.ws, fq, wkt, query.qualityProfile, query.disableQualityFilter, query.disableAllQualityFilters, newName)
                 },
                 /**
                  * Create a new query #Layer
@@ -842,7 +848,7 @@
                         $.merge(fqs, [newFq])
                     }
 
-                    return this.registerLayer(query.bs, query.ws, fqs, query.wkt, newName).then(function (data) {
+                    return this.registerLayer(query.bs, query.ws, fqs, query.wkt, query.qualityProfile, query.disableQualityFilter, query.disableAllQualityFilters, newName).then(function (data) {
                         if (data == null) {
                             return null;
                         } else {
@@ -859,6 +865,9 @@
                  * @param {String} hubUrl biocache-hub URL
                  * @param {List} fqs q and fq terms
                  * @param {String} wkt (optional) WKT
+                 * @param {String} qualityProfile (optional) quality profile
+                 * @param {Array} disableQualityFilter (optional) quality filters to disable
+                 * @param {Boolean} disableAllQualityFilters (optional) whether to disable all quality filters
                  * @param {newName} name (optional) name for display
                  * @returns {Promise(Layer)}
                  *
@@ -879,7 +888,7 @@
                  *      "name": ""
                  *  }
                  */
-                registerLayer: function (bs, ws, fq, wkt, name) {
+                registerLayer: function (bs, ws, fq, wkt, qualityProfile, disableQualityFilter, disableAllQualityFilters, name) {
                     fq = fq.slice();
                     for (var i = 0; i < fq.length; i++) {
                         if (fq[i] === '*:*') fq.splice(i, 1)
@@ -889,8 +898,8 @@
                         q = fq[0];
                         fq.splice(0, 1)
                     }
-                    if (fq.length > 0 || (wkt !== undefined && wkt !== null && wkt.length > 0)) {
-                        return this.registerParam(bs, q, fq, wkt).then(function (data) {
+                    if (fq.length > 0 || (wkt !== undefined && wkt !== null && wkt.length > 0) || qualityProfile || disableQualityFilter || disableAllQualityFilters != null) {
+                        return this.registerParam(bs, q, fq, wkt, qualityProfile, disableQualityFilter, disableAllQualityFilters).then(function (data) {
                             if (data != null) {
                                 return {
                                     q: $.merge([q], fq),

--- a/grails-app/assets/javascripts/spApp/service/urlParamsService.js
+++ b/grails-app/assets/javascripts/spApp/service/urlParamsService.js
@@ -212,7 +212,7 @@
                             if (wkt !== undefined && wkt !== null) query.wkt = wkt;
                             if (qualityProfile !== undefined && qualityProfile !== null && qualityProfile) query.qualityProfile = qualityProfile;
                             if (disableAllQualityFilters !== undefined && disableAllQualityFilters !== null && disableAllQualityFilters) query.disableAllQualityFilters = disableAllQualityFilters;
-                            if (disableQualityFilter !== undefined && disableQualityFilter !== null && disableQualityFilter) query.disableQualityFilter = disableQualityFilter;
+                            if (Array.isArray(disableQualityFilter) && disableQualityFilter.length) query.disableQualityFilter = disableQualityFilter;
 
                             promises.push(BiocacheService.queryTitle(query).then(function (response) {
                                 query.name = response;


### PR DESCRIPTION
Extend data quality filter parameter support to `registerParams` as well as `registerLayer`