### PR TITLE
Purge logback to use with tomcat >= 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,15 @@ repositories {
     maven { url "https://repo.grails.org/grails/core" }
 }
 
+configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+        exclude group: 'ch.qos.logback', module: 'logback-classic'
+        exclude group: 'ch.qos.logback', module: 'logback-core'
+    }
+}
+
 dependencies {
-    compile "org.springframework.boot:spring-boot-starter-logging"
     compile "org.springframework.boot:spring-boot-autoconfigure"
     compile "org.grails:grails-core"
     compile "org.springframework.boot:spring-boot-starter-actuator"


### PR DESCRIPTION
Fix for https://github.com/AtlasOfLivingAustralia/spatial-hub/issues/261 that permits to run `spatial-service` in tomcat 8 and above.

Similar to:
https://github.com/AtlasOfLivingAustralia/sds-webapp2/issues/8