### PR TITLE
Fix area report for species group Fishes. Fix default maximum for spe…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id 'com.bertramlabs.asset-pipeline' version '2.5.0'
 }
 
-version "0.4"
+version "0.4.0.1"
 group "au.org.ala"
 
 apply plugin:"eclipse"

--- a/grails-app/assets/javascripts/spApp/controller/areaReportCtrl.js
+++ b/grails-app/assets/javascripts/spApp/controller/areaReportCtrl.js
@@ -365,7 +365,7 @@
                         });
 
                         $.each(['Algae', 'Amphibians', 'Angiosperms', 'Animals', 'Arthropods', 'Bacteria', 'Birds',
-                            'Bryophytes', 'Chromista', 'Crustaceans', 'Dicots', 'FernsAndAllies', 'Fish', 'Fungi',
+                            'Bryophytes', 'Chromista', 'Crustaceans', 'Dicots', 'FernsAndAllies', 'Fishes', 'Fungi',
                             'Gymnosperms', 'Insects', 'Mammals', 'Molluscs', 'Monocots', 'Plants', 'Protozoa', 'Reptiles'], function (i, v) {
                             $scope.items.push({
                                 name: v,

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -527,6 +527,9 @@ rangeDataTypes:
   - 'tdouble'
   - 'tfloat'
   - 'tdate'
+  - 'float'
+  - 'double'
+  - 'date'
 
 numberOfIntervalsForRangeData: 7
 #
@@ -537,7 +540,7 @@ numberOfIntervalsForRangeData: 7
 
 date.facet: 'occurrence_date'
 date.min: '1780-01-01'
-date.max: '2020-01-01'
+date.max: '2030-01-01'
 
 #
 # Override the list of grouped facets from biocache-service (biocacheService.url/search/grouped/facets).


### PR DESCRIPTION
These are changes to the default config and a hardcoded string.
- Fix area report for species group Fishes so it does not always report `0`.
- Fix default maximum for species date filter so it does not automatically filter out 2020 and 2021 occurrences.
- Support a wider variety of index/fields data types as ranged facets. This is required to support the pipelines SOLR schema datatype changes.


