### PR TITLE
no spaces in OpenStreetMap; use https

### DIFF
--- a/embedExample.html
+++ b/embedExample.html
@@ -62,7 +62,7 @@
                 "exportType": "outline"
             },
             "osm": {
-                "name": "Open Street Map",
+                "name": "OpenStreetMap",
                 "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                 "type": "xyz",
                 "exportType": "minimal",

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -349,14 +349,14 @@ startup:
 #            link: 'https://www.openstreetmap.org/about'
 #            invalidProjections: ['3857']
         osm:
-            name: 'Open Street Map'
+            name: 'OpenStreetMap'
             url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
             type: 'xyz'
             exportType: 'minimal'
             link: 'https://www.openstreetmap.org/about'
             projections: ['3857']
             layerParams:
-                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 
         google_satellite:
             name: 'Satellite'


### PR DESCRIPTION
This is a minor change: removing the spaces in "OpenStreetMap" to match the correct name, and using HTTPS instead of HTTP for the licence URL.

I have however not tested anything after making the changes, assuming they are trivial.