### PR TITLE
#436 impl(query on authoritative species list )

### DIFF
--- a/grails-app/assets/javascripts/spApp/directive/listsList.js
+++ b/grails-app/assets/javascripts/spApp/directive/listsList.js
@@ -97,7 +97,7 @@
                                         var query = data;
                                         var limit = 200;
                                         if (items.length > limit ) {
-                                            alert("Biocache only returns the occurrences of the first 200 names in non-authoritative list.");
+                                            alert("Note: only the first 200 names will be used when when adding species to the map (for user-uploaded checklists)");
                                             query = items.slice(0,limit).join(" OR ") +")";
                                         }
                                         scope._custom()({

--- a/grails-app/assets/javascripts/spApp/directive/listsList.js
+++ b/grails-app/assets/javascripts/spApp/directive/listsList.js
@@ -32,6 +32,7 @@
                                         lastUpdated: data[i].lastUpdated,
                                         itemCount: data[i].itemCount,
                                         fullName: data[i].fullName,
+                                        isAuthoritative:data[i].isAuthoritative,
                                         selected: false
                                     })
                                 }
@@ -79,13 +80,33 @@
                                 found.selected = true;
                                 scope.selection = found;
 
-                                ListsService.getItemsQ(found.dataResourceUid).then(function (data) {
+                                //If the list is authoritative, Biocache builds index against species_list_uid (over night)
+                                //We should use q=species_list_uid:drxxxx
+                                if (found.isAuthoritative) {
+
                                     scope._custom()({
-                                        q: [data],
+                                        q: ["species_list_uid:" + found.dataResourceUid],
                                         name: found.listName,
                                         species_list: found.dataResourceUid
                                     })
-                                })
+                                } else {
+                                    //q=qid:xxxxxxxxxx
+                                    ListsService.getItemsQ(found.dataResourceUid).then(function (data) {
+                                        //example: (lsid:xxxx OR lsid:xxxx)
+                                        var items = data.split(" OR ");
+                                        var query = data;
+                                        var limit = 200;
+                                        if (items.length > limit ) {
+                                            alert("Biocache only returns the occurrences of the first 200 names in non-authoritative list.");
+                                            query = items.slice(0,limit).join(" OR ") +")";
+                                        }
+                                        scope._custom()({
+                                            q: [query],
+                                            name: found.listName,
+                                            species_list: found.dataResourceUid
+                                        })
+                                    })
+                                }
 
                             }
                         };

--- a/grails-app/assets/javascripts/spApp/templates/listsList.tpl.htm
+++ b/grails-app/assets/javascripts/spApp/templates/listsList.tpl.htm
@@ -1,13 +1,13 @@
 <div class="">
     <div class="">
         <div class="">
-            <table class="table table-striped fixed-head layers-table" style="width:430px">
+            <table class="table table-striped fixed-head layers-table" style="width:480px" name="speciesList">
                 <caption>
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="input-group">
                                 <input type="text" class="form-control" placeholder="Filter"
-                                       ng-model="searchLists">
+                                       ng-model="searchLists" name="searchInSpeciesList">
                                 <div class="input-group-addon"><i class="fa fa-search"></i></div>
                             </div>
                         </div>
@@ -47,7 +47,7 @@
                     <td style="width:10px" class="td-vertical-align text-center"><input type="checkbox"
                                                                                         ng-model="item.selected"
                                                                                         ng-click="select(item)"></td>
-                    <td class="td-vertical-align table-text-ellipsis" style="width:300px"><a target="_blank"
+                    <td class="td-vertical-align table-text-ellipsis" style="width:300px"><span title="Authoritative list" ng-show="item.isAuthoritative" class="glyphicon glyphicon-ok-circle"></span><a target="_blank"
                                                                                              href="{{ itemUrl(item) }}">{{
                         item.listName }}</a></td>
                     <td style="width:100px" class="td-vertical-align text-right">{{ item.lastUpdated | date: short}}

--- a/src/integration-test/groovy/AddSpeciesSpec.groovy
+++ b/src/integration-test/groovy/AddSpeciesSpec.groovy
@@ -130,4 +130,45 @@ class AddSpeciesSpec extends GebSpec {
         waitFor 10, {legendModule.title == "my test species (Australia)"}
         Thread.sleep(pause)
     }
+
+    def "Add authoritative speciesList to Australia"() {
+        when:
+        menuModule.clickMenu("Add to map ") //NOTICE: space
+        menuModule.clickMenuitem("Species")
+
+        then:
+        waitFor 20, {  addSpeciesModule.title == "Add a species layer to the map"}
+
+        and:
+        addSpeciesModule.chooseListInputOption.click()
+
+        then:
+        waitFor 15, {addSpeciesModule.searchInSpeciesListInput.displayed}
+
+        when:
+        addSpeciesModule.searchInSpeciesListInput.value('GRIIS')
+
+        then:
+        waitFor 10, { addSpeciesModule.speciesListTable.displayed }
+        Thread.sleep(pause)
+        addSpeciesModule.findSpeciesInTable("GRIIS - Global Register of Introduced and Invasive Species - Australia",1).displayed
+        assert addSpeciesModule.isAuthoritative("GRIIS - Global Register of Introduced and Invasive Species - Australia",1) == true
+
+        and:
+        addSpeciesModule.selectSpeciesInTable("GRIIS - Global Register of Introduced and Invasive Species - Australia", 0)
+
+        when:
+        interact {
+            modalModule.moveToStep(3)
+            modalModule.selectArea("Australia")
+        }
+
+        and:
+        addSpeciesModule.nextBtn.click()
+
+        then:
+        waitFor 30, { layerListModule.getLayer("GRIIS - Global Register of Introduced and Invasive Species - Australia (Australia)").displayed }
+        waitFor 100, {legendModule.title == "GRIIS - Global Register of Introduced and Invasive Species - Australia (Australia)"}
+        Thread.sleep(pause*3)
+    }
 }

--- a/src/integration-test/groovy/page/AddSpeciesModule.groovy
+++ b/src/integration-test/groovy/page/AddSpeciesModule.groovy
@@ -10,6 +10,9 @@ class AddSpeciesModule extends ModalModule {
         parseSpeciesListBtn(required:false){ $('button[name=parseSpeciesList]') }
         speciesListTable(required:false){ $('table[name=speciesList]') }
         newListNameInput(required:false){ $('input[name=newListName]') }
+
+        chooseListInputOption(required:false){ $('input[value="speciesList"]') }
+        searchInSpeciesListInput(required:false){ $('input[name="searchInSpeciesList"]') }
     }
 
     /**
@@ -21,5 +24,21 @@ class AddSpeciesModule extends ModalModule {
     def findSpeciesInTable(String name, int col) {
         def rols =  speciesListTable.find("tr td", text: name).parent()
         return  rols.find("td")[col]
+    }
+
+    def isAuthoritative(String name, int col) {
+        def rols =  speciesListTable.find("tr td", text: name).parent()
+        return  rols.find("td")[col].has("span[title='Authoritative list']").size() == 1
+    }
+
+    /**
+     * Select/deselect the species.
+     * @param name
+     * @param col of checkbox
+     * @return
+     */
+    def selectSpeciesInTable(String name, int col) {
+        def rols =  speciesListTable.find("tr td", text: name).parent()
+        return  rols.find("td")[col].click()
     }
 }


### PR DESCRIPTION
Biocache is not able to query those species lists which contains a large number of species. 
This work uses two ways:
1, for authoritative species list, use species_list_uid: dr494, instead of querying on a list of species directly.
2, for non-authoritative species list,  popup warning to user: only return the first 200 species 