### PR TITLE
Allow setting the language in spatial-hub

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -22,8 +22,6 @@ grails:
         upload:
             maxFileSize: 10000000
             maxRequestSize: 10000000
-i18n:
-  region: 'default'
 
 layersService:
     url: 'https://spatial.ala.org.au/ws'

--- a/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
+++ b/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
@@ -98,12 +98,8 @@ class PortalController {
                     config.spApp.each { k, v ->
                         spApp.put(k, v.class.newInstance(params.get(k, v)))
                     }
-                    if (params.get("lang")) {
-                        config.i18n?.currentRegion = params.get("lang")
-                    } else {
-                        config.i18n?.currentRegion = null;
-                    }
 
+                    config.i18n?.currentRegion = org.springframework.context.i18n.LocaleContextHolder.getLocale()?.getLanguage()
 
                     render(view: 'index',
                             model: [config     : config,

--- a/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
+++ b/grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy
@@ -8,6 +8,7 @@ import org.apache.commons.httpclient.methods.StringRequestEntity
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.utils.URLEncodedUtils
 import org.apache.http.entity.ContentType
+import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.multipart.MultipartHttpServletRequest
 import org.apache.http.client.methods.HttpPost
@@ -99,15 +100,14 @@ class PortalController {
                         spApp.put(k, v.class.newInstance(params.get(k, v)))
                     }
 
-                    config.i18n?.currentRegion = org.springframework.context.i18n.LocaleContextHolder.getLocale()?.getLanguage()
-
                     render(view: 'index',
-                            model: [config     : config,
-                                    userId     : userId,
-                                    userDetails: authService.userDetails(),
-                                    sessionId  : sessionService.newId(userId),
-                                    messagesAge: messageService.messagesAge,
-                                    hub        : hub,
+                            model: [config       : config,
+                                    language     : LocaleContextHolder.getLocale()?.getLanguage(),
+                                    userId       : userId,
+                                    userDetails  : authService.userDetails(),
+                                    sessionId    : sessionService.newId(userId),
+                                    messagesAge  : messageService.messagesAge,
+                                    hub          : hub,
                                     custom_facets: toMapOfLists(config.biocacheService.custom_facets)])
                 } else if (!authDisabled && userId == null) {
                     login()
@@ -696,7 +696,12 @@ class PortalController {
     }
 
     def embedExample() {
-        render(view: 'embedExample')
+        render(view: 'embedExample',
+                model: [config   : config,
+                        language : LocaleContextHolder.getLocale()?.getLanguage(),
+                        userId   : userId,
+                        sessionId: sessionService.newId(userId),
+                ])
     }
 
     private def toList(Object o) {

--- a/grails-app/views/portal/embedExample.gsp
+++ b/grails-app/views/portal/embedExample.gsp
@@ -76,7 +76,7 @@
             '${config.collections.url}/**',
             '${config.phylolink.url}/**'
         ],
-        i18n: '${config.i18n?.region?:"default"}',
+        i18n: '${language:"default"}',
         editable: ${params.edit?:'false'}
     };
 

--- a/grails-app/views/portal/index.gsp
+++ b/grails-app/views/portal/index.gsp
@@ -77,7 +77,7 @@
         baseLayers: ${(config.startup.baselayers as grails.converters.JSON).toString().encodeAsRaw()},
         defaultBaseLayer: '${config.startup.baselayer.default}',
 
-        i18n: '${config.i18n?.currentRegion}',
+        i18n: '${language}',
 
         <g:if test="${config.flickr.url}">
         flickrUrl: '${config.flickr.url}',

--- a/grails-app/views/portal/index.gsp
+++ b/grails-app/views/portal/index.gsp
@@ -77,9 +77,7 @@
         baseLayers: ${(config.startup.baselayers as grails.converters.JSON).toString().encodeAsRaw()},
         defaultBaseLayer: '${config.startup.baselayer.default}',
 
-        <g:if test="${config.i18n?.currentRegion}">
         i18n: '${config.i18n?.currentRegion}',
-        </g:if>
 
         <g:if test="${config.flickr.url}">
         flickrUrl: '${config.flickr.url}',


### PR DESCRIPTION
Use the same grails mechanism as the other services for picking the language.
This allows us to maintain the same language across services using a single cookie.

We do this by adding an xml in our docker builds:
```
<?xml version="1.0" encoding="UTF-8"?>
<beans xmlns="http://www.springframework.org/schema/beans"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.springframework.org/schema/beans
        http://www.springframework.org/schema/beans/spring-beans.xsd">
    <bean id="localeResolver" class="org.springframework.web.servlet.i18n.CookieLocaleResolver">
        <property name="defaultLocale" value="nl"/>
        <property name="cookieName" value="vbp-lang"/>
        <property name="cookieMaxAge" value="31536000"/>
        <property name="cookieHttpOnly" value="false" />
        <property name="cookieSecure" value="true" />
    </bean>
</beans>
```

But without that xml, this change should not change any behavior 🙏
As the default grails also using the lang url parameter to set the language.
(Except it will save the selected language for the duration of the session and won't have to be provided on every request)
